### PR TITLE
feat: load remote study data on user change

### DIFF
--- a/js/core-auth-store.js
+++ b/js/core-auth-store.js
@@ -52,6 +52,22 @@
     localStorage.setItem(USER_KEY, u);
     ensureStudyDataFor(u);
     window.dispatchEvent(new Event('user:changed'));
+    // 서버에 저장된 공부 데이터를 불러와 병합
+    try {
+      fetch(`/api/data/${encodeURIComponent(u)}`)
+        .then((res) => (res.ok ? res.json() : Promise.reject(res.status)))
+        .then((remote) => {
+          if (!remote || typeof remote !== 'object') return;
+          const raw = localStorage.getItem(SD_KEY);
+          const sd = raw ? JSON.parse(raw) : {};
+          const local = sd[u] || {};
+          sd[u] = { ...local, ...remote };
+          localStorage.setItem(SD_KEY, JSON.stringify(sd));
+        })
+        .catch((err) => console.warn('studyData fetch failed', err));
+    } catch (err) {
+      console.warn('studyData fetch failed', err);
+    }
     return u;
   }
 


### PR DESCRIPTION
## Summary
- Merge server study data after setting current user

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a8d85784588330a16cdfa6e4e27433